### PR TITLE
Salt security issue - twin-bcrypt.js

### DIFF
--- a/twin-bcrypt/twin-bcrypt.js
+++ b/twin-bcrypt/twin-bcrypt.js
@@ -44,12 +44,12 @@ module.exports = function(RED) {
       var field = config.field || 'payload';
       var action = config.action || 'encrypt';
       var rounds = parseInt(rounds);
-      var salt = bcryptjs.genSalt(rounds);
 
       this.on('input', function(msg) {
           var data = get(msg, field);
 
           if (action === 'encrypt') {
+              var salt = bcryptjs.genSalt(rounds);
               var newHash = bcryptjs.hashSync(data, salt);
 
               set(msg, field, newHash, true);


### PR DESCRIPTION
Salt is only changed upon flow refresh or restart of node-red when in RED.nodes.createNode(this, config);
Move to this.on('input', function(msg)  inside of encrypt if than statement.

This way each new msg sent to the node that is to be encrypted gets a new salt